### PR TITLE
RMA-02: Implement Delete User Service

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,7 +2,14 @@
 
 namespace App\Exceptions;
 
+use App\Http\Resources\Errors\UnAuthenticatedResource;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Response;
+use Laravel\Sanctum\Exceptions\MissingAbilityException;
 use Throwable;
 
 class Handler extends ExceptionHandler
@@ -26,5 +33,14 @@ class Handler extends ExceptionHandler
         $this->reportable(function (Throwable $e) {
             //
         });
+    }
+
+    public function render($request, Throwable $e): Response|JsonResponse|\Symfony\Component\HttpFoundation\Response|RedirectResponse|ResponseFactory
+    {
+        if ($e instanceof MissingAbilityException || $e instanceof AuthenticationException) {
+            return (new UnAuthenticatedResource())->toResponse($request);
+        }
+
+        return parent::render($request, $e);
     }
 }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -9,4 +9,14 @@ use Illuminate\Routing\Controller as BaseController;
 class Controller extends BaseController
 {
     use AuthorizesRequests, ValidatesRequests;
+
+    /**
+     * Initiate auth sanctum middleware with ability's to access API
+     *
+     * @return void
+     */
+    public function needsAccessApiToken(): void
+    {
+        $this->middleware(['auth:sanctum', 'ability:access-api']);
+    }
 }

--- a/app/Http/Controllers/Service/User/DeleteController.php
+++ b/app/Http/Controllers/Service/User/DeleteController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Service\User;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\MessageResource;
+use App\Repositories\EloquentRepository;
+use Illuminate\Http\Request;
+
+class DeleteController extends Controller
+{
+    /**
+     * Eloquent user repository instance
+     *
+     * @var EloquentRepository
+     */
+    public readonly EloquentRepository $eloquentRepository;
+
+    /**
+     * Create a new controller instance
+     *
+     * @param  EloquentRepository  $eloquentRepository
+     */
+    public function __construct(EloquentRepository $eloquentRepository)
+    {
+        $this->needsAccessApiToken();
+        $this->eloquentRepository = $eloquentRepository;
+    }
+
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request): MessageResource
+    {
+        $user = $request->user();
+
+        $this->eloquentRepository->delete($user->id);
+
+        return new MessageResource('Goodbye!');
+    }
+}

--- a/app/Http/Resources/Errors/UnAuthenticatedResource.php
+++ b/app/Http/Resources/Errors/UnAuthenticatedResource.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Resources\Errors;
+
+use App\Enums\HttpStatusCode;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class UnAuthenticatedResource extends JsonResource
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct()
+    {
+        parent::__construct('Your\'re not authorized to access this endpoint!');
+    }
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return ['message' => $this->resource];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function withResponse(Request $request, JsonResponse $response): void
+    {
+        $response->setStatusCode(HttpStatusCode::UN_AUTHENTICATED->value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function with(Request $request): array
+    {
+        return [
+            'meta' => [
+                'statusText' => HttpStatusCode::UN_AUTHENTICATED->text(),
+                'timestamp'  => now()->toDateTimeLocalString(),
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/MessageResource.php
+++ b/app/Http/Resources/MessageResource.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Enums\HttpStatusCode;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class MessageResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'message' => $this->resource,
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function with(Request $request): array
+    {
+        return [
+            'meta' => [
+                'statusText' => HttpStatusCode::OK->text(),
+                'timestamp'  => now()->toDateTimeLocalString(),
+            ],
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,13 +5,14 @@ namespace App\Models;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable, SoftDeletes;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Models/UserProfile.php
+++ b/app/Models/UserProfile.php
@@ -5,17 +5,25 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class UserProfile extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     /**
-     * Without timestamp
+     * The name of the "updated at" column.
      *
-     * @var bool
+     * @var string
      */
-    public $timestamps = false;
+    const CREATED_AT = null;
+
+    /**
+     * The name of the "updated at" column.
+     *
+     * @var string
+     */
+    const UPDATED_AT = null;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\User;
+
+class UserObserver
+{
+    /**
+     * Handle the User "created" event.
+     */
+    public function created(User $user): void
+    {
+        //
+    }
+
+    /**
+     * Handle the User "updated" event.
+     */
+    public function updated(User $user): void
+    {
+        //
+    }
+
+    /**
+     * Handle the User "deleted" event.
+     */
+    public function deleted(User $user): void
+    {
+        $user->profile()->delete();
+    }
+
+    /**
+     * Handle the User "restored" event.
+     */
+    public function restored(User $user): void
+    {
+        //
+    }
+
+    /**
+     * Handle the User "force deleted" event.
+     */
+    public function forceDeleted(User $user): void
+    {
+        //
+    }
+}

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -28,6 +28,8 @@ class UserObserver
     public function deleted(User $user): void
     {
         $user->profile()->delete();
+
+        $user->tokens()->delete();
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Http\Controllers\Service\User\DeleteController;
 use App\Http\Controllers\Service\User\RegisterController;
 use App\Repositories\Eloquent\EloquentUserRepository;
 use App\Repositories\EloquentRepository;
@@ -23,6 +24,10 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->app->when(RegisterController::class)
+            ->needs(EloquentRepository::class)
+            ->give(EloquentUserRepository::class);
+
+        $this->app->when(DeleteController::class)
             ->needs(EloquentRepository::class)
             ->give(EloquentUserRepository::class);
     }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use App\Observers\UserObserver;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -25,7 +27,7 @@ class EventServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        User::observe(UserObserver::class);
     }
 
     /**

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -19,6 +19,7 @@ return new class extends Migration
             $table->string('password');
             $table->rememberToken();
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 
@@ -27,6 +28,9 @@ return new class extends Migration
      */
     public function down(): void
     {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
         Schema::dropIfExists('users');
     }
 };

--- a/database/migrations/2023_12_19_164310_create_user_profiles_table.php
+++ b/database/migrations/2023_12_19_164310_create_user_profiles_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             $table->enum('gender', Gender::values())->nullable();
             $table->date('dob');
             $table->string('timezone');
+            $table->softDeletes();
 
             $table->foreign('user_id')
                 ->references('id')
@@ -33,6 +34,9 @@ return new class extends Migration
      */
     public function down(): void
     {
+        Schema::table('user_profiles', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
         Schema::dropIfExists('user_profiles');
     }
 };

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,5 +18,6 @@ use Illuminate\Support\Facades\Route;
 Route::prefix('v1')->group(function () {
     Route::prefix('user')->name('api.user.')->group(function (Router $router) {
         $router->post('', User\RegisterController::class)->name('register');
+        $router->delete('', User\DeleteController::class)->name('delete');
     });
 });

--- a/tests/Feature/User/UserSuccessfullyDeleteTheirOwnDataTest.php
+++ b/tests/Feature/User/UserSuccessfullyDeleteTheirOwnDataTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\User;
+
+use App\Models\User;
+use App\Models\UserProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Date;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class UserSuccessfullyDeleteTheirOwnDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_will_receive_goodbye_message_when_current_user_is_deleted(): void
+    {
+        Date::setTestNow();
+        $user = Sanctum::actingAs(User::factory()->create(), ['access-api']);
+        UserProfile::factory()->belongsToUser($user)->create();
+
+        $response = $this->deleteJson(route('api.user.delete'));
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('data', ['message' => 'Goodbye!'])
+            ->assertJsonPath('meta', [
+                'statusText' => 'ok',
+                'timestamp'  => now()->toDateTimeLocalString(),
+            ]);
+        $this->assertDatabaseHas('users', [
+            ...$user->only('id', 'email', 'name'),
+            'deleted_at' => now(),
+        ]);
+        $this->assertDatabaseHas('user_profiles', [
+            'user_id'    => $user->id,
+            'deleted_at' => now(),
+        ]);
+    }
+}

--- a/tests/Feature/Validations/DeleteUserRequest/UnAuthenticateDeleteUserTest.php
+++ b/tests/Feature/Validations/DeleteUserRequest/UnAuthenticateDeleteUserTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\Validations\DeleteUserRequest;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Date;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class UnAuthenticateDeleteUserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function should_receive_un_authenticated_response_when_no_access_token_provide(): void
+    {
+        Date::setTestNow();
+        User::factory()->create();
+
+        $response = $this->deleteJson(route('api.user.delete'));
+
+        $response
+            ->assertUnauthorized()
+            ->assertJsonPath('data', ['message' => 'Your\'re not authorized to access this endpoint!'])
+            ->assertJsonPath('meta', [
+                'statusText' => 'unauthenticated/unauthorized',
+                'timestamp'  => now()->toDateTimeLocalString(),
+            ]);
+    }
+
+    /** @test */
+    public function should_receive_un_authenticated_response_when_wrong_access_token_name_provided(): void
+    {
+        Date::setTestNow();
+        Sanctum::actingAs(User::factory()->create(), ['not-access-api']);
+
+        $response = $this->deleteJson(route('api.user.delete'));
+
+        $response
+            ->assertUnauthorized()
+            ->assertJsonPath('data', ['message' => 'Your\'re not authorized to access this endpoint!'])
+            ->assertJsonPath('meta', [
+                'statusText' => 'unauthenticated/unauthorized',
+                'timestamp'  => now()->toDateTimeLocalString(),
+            ]);
+    }
+}

--- a/tests/Unit/Http/Resources/ErrorUnAuthenticatedResourceTest.php
+++ b/tests/Unit/Http/Resources/ErrorUnAuthenticatedResourceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\Http\Resources;
+
+use App\Http\Resources\Errors\UnAuthenticatedResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class ErrorUnAuthenticatedResourceTest extends TestCase
+{
+    /** @test */
+    public function it_should_contains_response_422(): void
+    {
+        $mockRequest = Mockery::mock(Request::class);
+        $mockJsonResource = Mockery::spy(JsonResponse::class);
+        $resource = new UnAuthenticatedResource();
+        $resource->withResponse($mockRequest, $mockJsonResource);
+
+        $this->assertEquals([
+            'message' => 'Your\'re not authorized to access this endpoint!',
+        ], $resource->toArray($mockRequest));
+        $mockJsonResource->shouldHaveReceived('setStatusCode')->with(401)->once();
+    }
+}


### PR DESCRIPTION
**WHY**

In order to give ability to users so they can delete their user's data, we need to provide an endpoint that have ability to remove user's data including all related data that are connected with current users record

**WHAT**

- Adding new endpoint in user resource to delete users record's
- Create user observer to remove database records that connected with deleted users
- Implement `auth:sanctum` middleware to delete users record