### PR TITLE
RMA-09: Create API Endpoint to Update User

### DIFF
--- a/app/Http/Controllers/Service/UserController.php
+++ b/app/Http/Controllers/Service/UserController.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Http\Controllers\Service;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\UserResource;
+use App\Repositories\EloquentRepository;
+use Illuminate\Http\Request;
+
+class UserController extends Controller
+{
+    /**
+     * Eloquent user repository instance
+     *
+     * @var EloquentRepository
+     */
+    public readonly EloquentRepository $eloquentRepository;
+
+    /**
+     * Create a new controller instance
+     *
+     * @param  EloquentRepository  $eloquentRepository
+     */
+    public function __construct(EloquentRepository $eloquentRepository)
+    {
+        $this->eloquentRepository = $eloquentRepository;
+    }
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request): UserResource
+    {
+        $user = $this->eloquentRepository->updateWithProfile($request->id,
+            $request->only([
+                'userName',
+                'firstName',
+                'lastName',
+                'email',
+                'password',
+                'gender',
+                'dob',
+                'location',
+            ])
+        );
+
+        return new UserResource($user);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/Service/UserController.php
+++ b/app/Http/Controllers/Service/UserController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Service;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\User\UpdateUserRequest;
 use App\Http\Resources\UserResource;
 use App\Repositories\EloquentRepository;
 use Illuminate\Http\Request;
@@ -70,7 +71,7 @@ class UserController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request): UserResource
+    public function update(UpdateUserRequest $request): UserResource
     {
         $user = $this->eloquentRepository->updateWithProfile($request->id,
             $request->only([

--- a/app/Http/Controllers/Service/UserController.php
+++ b/app/Http/Controllers/Service/UserController.php
@@ -23,6 +23,7 @@ class UserController extends Controller
      */
     public function __construct(EloquentRepository $eloquentRepository)
     {
+        $this->needsAccessApiToken();
         $this->eloquentRepository = $eloquentRepository;
     }
 

--- a/app/Http/Requests/User/UpdateUserRequest.php
+++ b/app/Http/Requests/User/UpdateUserRequest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Requests\User;
+
+use App\Enums\Gender;
+use App\Http\Resources\Errors\UnprocessableResource;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+
+class UpdateUserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'userName'  => ['nullable', Rule::unique('users', 'name')->ignore($this->id)],
+            'email'     => ['nullable', Rule::unique('users', 'email')->ignore($this->id)],
+            'password'  => ['nullable', 'min:11'],
+            'firstName' => ['nullable', 'max:100'],
+            'lastName'  => ['nullable', 'max:100'],
+            'gender'    => ['nullable', Rule::in(Gender::values())],
+            'dob'       => ['nullable', 'date_format:Y-m-d'],
+            'location'  => ['nullable', 'timezone:all'],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return array
+     */
+    public function attributes(): array
+    {
+        return [
+            'userName'  => 'user name',
+            'firstName' => 'first name',
+            'lastName'  => 'last name',
+            'dob'       => 'date of birth',
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws ValidationException
+     */
+    protected function failedValidation(Validator $validator): void
+    {
+        if ($this->expectsJson()) {
+            $resource = new UnprocessableResource(new ValidationException($validator));
+
+            throw new HttpResponseException($resource->toResponse($this));
+        }
+
+        parent::failedValidation($validator);
+    }
+}

--- a/app/Http/Resources/DynamicStatusCode.php
+++ b/app/Http/Resources/DynamicStatusCode.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Enums\HttpStatusCode;
+use Illuminate\Http\Request;
+
+interface DynamicStatusCode
+{
+    /**
+     * Get the current status code by the given request
+     *
+     * @param  Request  $request
+     * @return HttpStatusCode
+     */
+    public function getStatusCode(Request $request): HttpStatusCode;
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Console\Commands\Notification\SendBirthDayMessageCommand;
 use App\Http\Controllers\Service\User\DeleteController;
 use App\Http\Controllers\Service\User\RegisterController;
+use App\Http\Controllers\Service\UserController;
 use App\Repositories\Eloquent\EloquentUserRepository;
 use App\Repositories\EloquentRepository;
 use Illuminate\Support\ServiceProvider;
@@ -29,6 +30,10 @@ class AppServiceProvider extends ServiceProvider
             ->give(EloquentUserRepository::class);
 
         $this->app->when(DeleteController::class)
+            ->needs(EloquentRepository::class)
+            ->give(EloquentUserRepository::class);
+
+        $this->app->when(UserController::class)
             ->needs(EloquentRepository::class)
             ->give(EloquentUserRepository::class);
 

--- a/app/Repositories/Eloquent/EloquentUserRepository.php
+++ b/app/Repositories/Eloquent/EloquentUserRepository.php
@@ -9,6 +9,13 @@ use App\Repositories\EloquentRepository;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Date;
 
+/**
+ * @extends EloquentRepository
+ *
+ * @method User create(array $attributes)
+ * @method User|null find(int $id)
+ * @method User update(int $id, array $attributes)
+ */
 class EloquentUserRepository extends EloquentRepository
 {
     /**
@@ -119,6 +126,33 @@ class EloquentUserRepository extends EloquentRepository
 
         $user->access_token = $accessToken;
         $user->refresh_token = $refreshToken;
+
+        return $user;
+    }
+
+    /**
+     * Update existing user record including user profile by specified user's id
+     *
+     * @param  int  $id
+     * @param  array  $attributes
+     * @return User
+     */
+    public function updateWithProfile(int $id, array $attributes): User
+    {
+        $user = $this->find($id);
+        $user = $this->update($id, [
+            'name'  => $attributes['userName'] ?? $user->name,
+            'email' => $attributes['email'] ?? $user->email,
+        ]);
+
+        $userProfile = $user->profile;
+        $userProfile->update([
+            'first_name' => $attributes['firstName'] ?? $userProfile->first_name,
+            'last_name'  => $attributes['lastName'] ?? $userProfile->last_name,
+            'gender'     => $attributes['gender'] ?? $userProfile->gender,
+            'dob'        => $attributes['dob'] ?? $userProfile->dob,
+            'timezone'   => $attributes['location'] ?? $userProfile->timezone,
+        ]);
 
         return $user;
     }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,12 +2,13 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @extends Factory<User>
  */
 class UserFactory extends Factory
 {

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Service\User;
+use App\Http\Controllers\Service\UserController;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Route;
 
@@ -19,5 +20,6 @@ Route::prefix('v1')->group(function () {
     Route::prefix('user')->name('api.user.')->group(function (Router $router) {
         $router->post('', User\RegisterController::class)->name('register');
         $router->delete('', User\DeleteController::class)->name('delete');
+        $router->patch('{id}', [UserController::class, 'update'])->name('update');
     });
 });

--- a/tests/Feature/Events/Listener/SendMessageTest.php
+++ b/tests/Feature/Events/Listener/SendMessageTest.php
@@ -57,7 +57,7 @@ class SendMessageTest extends TestCase
     public function it_will_not_call_send_message_api_when_the_hours_is_less_then_9_am(): void
     {
         $timezone = 'Asia/Jakarta';
-        $pastDate = now($timezone)->subHours(12);
+        $pastDate = Date::createFromTime('08', '00', '00', $timezone);
         Date::setTestNow($pastDate);
         $today = now($timezone);
         $user = User::factory()->create();

--- a/tests/Feature/Middlewares/UnAuthenticatedToAccessUserEndpoint.php
+++ b/tests/Feature/Middlewares/UnAuthenticatedToAccessUserEndpoint.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature\Middlewares;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Date;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class UnAuthenticatedToAccessUserEndpoint extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     *
+     * @dataProvider routeDataProvider
+     */
+    public function should_receive_un_authenticated_response_when_no_access_token_provide(string $actionName): void
+    {
+        Date::setTestNow();
+        $user = User::factory()->create();
+
+        if ($actionName === 'update') {
+            $response = $this->patchJson(route("api.user.$actionName", $user->id));
+        } else {
+            $response = $this->deleteJson(route('api.user.delete'));
+        }
+
+        $response
+            ->assertUnauthorized()
+            ->assertJsonPath('data', ['message' => 'Your\'re not authorized to access this endpoint!'])
+            ->assertJsonPath('meta', [
+                'statusText' => 'unauthenticated/unauthorized',
+                'timestamp'  => now()->toDateTimeLocalString(),
+            ]);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider routeDataProvider
+     */
+    public function should_receive_un_authenticated_response_when_wrong_access_token_name_provided(string $actionName): void
+    {
+        Date::setTestNow();
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['not-access-api']);
+
+        if ($actionName === 'update') {
+            $response = $this->patchJson(route("api.user.$actionName", $user->id));
+        } else {
+            $response = $this->deleteJson(route('api.user.delete'));
+        }
+
+        $response
+            ->assertUnauthorized()
+            ->assertJsonPath('data', ['message' => 'Your\'re not authorized to access this endpoint!'])
+            ->assertJsonPath('meta', [
+                'statusText' => 'unauthenticated/unauthorized',
+                'timestamp'  => now()->toDateTimeLocalString(),
+            ]);
+    }
+
+    /**
+     * Get user routes name's
+     *
+     * @return array[]
+     */
+    public static function routeDataProvider(): array
+    {
+        return [
+            'delete user' => ['delete'],
+            'update user' => ['update'],
+        ];
+    }
+}

--- a/tests/Feature/User/UserSuccessfullyRegisterTest.php
+++ b/tests/Feature/User/UserSuccessfullyRegisterTest.php
@@ -30,11 +30,12 @@ class UserSuccessfullyRegisterTest extends TestCase
         $response
             ->assertCreated()
             ->assertJsonPath('data.user', [
+                'userName'  => $input['email'],
                 'email'     => $input['email'],
-                'gender'    => $input['gender'],
-                'dob'       => $input['dob'],
                 'firstName' => $input['firstName'],
                 'lastName'  => $input['lastName'],
+                'gender'    => $input['gender'],
+                'dob'       => $input['dob'],
                 'location'  => $input['location'],
             ])
             ->assertJsonPath('meta', [

--- a/tests/Feature/User/UserSuccessfullyUpdateTheirProfileTest.php
+++ b/tests/Feature/User/UserSuccessfullyUpdateTheirProfileTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Feature\User;
+
+use App\Models\User;
+use App\Models\UserProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class UserSuccessfullyUpdateTheirProfileTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    /** @test */
+    public function user_can_update_multiple_values()
+    {
+        $inputs = [
+            'userName'  => 'johndoe',
+            'email'     => 'johndoe@mail.com',
+            'firstName' => 'John',
+            'lastName'  => 'Doe',
+            'gender'    => 1,
+            'dob'       => '1979-01-12',
+            'location'  => 'Asia/Jakarta',
+        ];
+        $user = User::factory()->create([
+            'name'  => 'johnwick',
+            'email' => 'johnwick@mail.com',
+        ]);
+        $userProfile = UserProfile::factory()->belongsToUser($user)->create([
+            'first_name' => 'Jonathan',
+            'last_name'  => 'Wick',
+            'dob'        => '1980-12-01',
+            'gender'     => null,
+            'timezone'   => 'Asia/Kuala_Lumpur',
+        ]);
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->patchJson(route('api.user.update', $user->id), $inputs);
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('data.user', $inputs)
+            ->assertJsonMissing([
+                'userName' => $user->name,
+                ...$user->only('email'),
+                ...$userProfile->only([
+                    'first_name',
+                    'last_name',
+                    'gender',
+                    'dob',
+                    'location',
+                ]),
+            ])
+            ->assertJsonMissingPath('data.tokens')
+            ->assertJsonPath('meta.statusText', 'ok');
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider userProfileAttribute
+     */
+    public function user_can_only_update_a_single_value(string $field, string $newValue, array $attribute): void
+    {
+        $user = User::factory()->create($attribute['user']);
+        UserProfile::factory()->belongsToUser($user)->create($attribute['userProfile']);
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->patchJson(route('api.user.update', $user->id), [
+            $field => $newValue,
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonPath("data.user.$field", $newValue)
+            ->assertJsonMissingPath('data.tokens')
+            ->assertJsonPath('meta.statusText', 'ok');
+    }
+
+    /**
+     * Get user profile attributes to update
+     *
+     * @return array
+     */
+    public static function userProfileAttribute(): array
+    {
+        return [
+            'only update user name' => [
+                'userName',
+                'johndoe',
+                ['user' => ['name' => 'jenny'], 'userProfile' => []],
+            ],
+            'only update user email' => [
+                'email',
+                'johndoe@mail.com',
+                ['user' => ['email' => 'jennywick@mail.com'], 'userProfile' => []],
+            ],
+            'only update user first name' => [
+                'firstName',
+                'John',
+                ['user' => [], 'userProfile' => ['first_name' => 'Jenny']],
+            ],
+            'only update user last name' => [
+                'lastName',
+                'Doe',
+                ['user' => [], 'userProfile' => ['last_name' => 'Wick']],
+            ],
+            'only update user gender' => [
+                'gender',
+                '1',
+                ['user' => [], 'userProfile' => ['gender' => '0']],
+            ],
+            'only update user dob' => [
+                'dob',
+                '1985-01-12',
+                ['user' => [], 'userProfile' => ['dob' => '1985-12-01']],
+            ],
+            'only update user location' => [
+                'location',
+                'Asia/Jakarta',
+                ['user' => [], 'userProfile' => ['timezone' => 'Asia/Kuala_Lumpur']],
+            ],
+        ];
+    }
+}

--- a/tests/Feature/Validations/UpdateUserRequest/ValidateInputUserBirthdayTest.php
+++ b/tests/Feature/Validations/UpdateUserRequest/ValidateInputUserBirthdayTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Feature\Validations\UpdateUserRequest;
+
+use App\Models\User;
+use App\Models\UserProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Date;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ValidateInputUserBirthdayTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    /** @test */
+    public function it_should_not_has_error_input_user_birthday_when_the_value_is_unset(): void
+    {
+        Date::setTestNow();
+        $user = User::factory()->create();
+        UserProfile::factory()->belongsToUser($user)->create();
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->patchJson(route('api.user.update', ['id' => $user->id]), [
+            'email'     => $this->faker->email,
+            'password'  => $this->faker->password(11),
+            'firstName' => $this->faker->firstName,
+            'lastName'  => $this->faker->lastName,
+            'location'  => $this->faker->timezone,
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonMissingPath('data.errors');
+    }
+
+    /**
+     * @dataProvider invalidBirthdayValueDataProvider
+     *
+     * @test
+     *
+     * @param  string  $dobFormat
+     */
+    public function it_has_error_input_user_birthday_when_the_value_format_is_not_y_m_d(string $dobFormat): void
+    {
+        Date::setTestNow();
+        $user = User::factory()->create();
+        UserProfile::factory()->belongsToUser($user)->create();
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->patchJson(route('api.user.update', ['id' => $user->id]), [
+            'dob' => $this->faker->date($dobFormat),
+        ]);
+
+        $response
+            ->assertUnprocessable()
+            ->assertJson([
+                'data' => [
+                    'errors' => [
+                        'dob' => [
+                            __('validation.date_format', ['attribute' => 'date of birth', 'format' => 'Y-m-d']),
+                        ],
+                    ],
+                ],
+                'meta' => [
+                    'statusText' => 'unprocessable entity',
+                    'timestamp'  => Date::now()->toDateTimeLocalString(),
+                ],
+            ])
+            ->assertJsonMissingPath('data.errors.userName')
+            ->assertJsonMissingPath('data.errors.firstName')
+            ->assertJsonMissingPath('data.errors.lastName')
+            ->assertJsonMissingPath('data.errors.email')
+            ->assertJsonMissingPath('data.errors.password')
+            ->assertJsonMissingPath('data.errors.gender')
+            ->assertJsonMissingPath('data.errors.location');
+    }
+
+    /**
+     * Get invalid birthday date value
+     *
+     * @return array
+     */
+    public static function invalidBirthdayValueDataProvider(): array
+    {
+        return [
+            'using format Ymd'         => ['Ymd'],
+            'using format m-Y-d'       => ['m-Y-d'],
+            'using format d-m-Y'       => ['d-m-Y'],
+            'using format m-d-Y'       => ['m-d-Y'],
+            'using format y-m-d H:i'   => ['y-m-d H:i'],
+            'using format y-m-d H:i:s' => ['y-m-d H:i:s'],
+        ];
+    }
+}

--- a/tests/Feature/Validations/UpdateUserRequest/ValidateInputUserEmailTest.php
+++ b/tests/Feature/Validations/UpdateUserRequest/ValidateInputUserEmailTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Feature\Validations\UpdateUserRequest;
+
+use App\Models\User;
+use App\Models\UserProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Date;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ValidateInputUserEmailTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    /** @test */
+    public function it_should_not_receive_error_input_unique_user_email_if_the_value_is_similar_with_existing_user_email(): void
+    {
+        Date::setTestNow();
+        $user = User::factory()->create(['email' => $this->faker->email]);
+        UserProfile::factory()->belongsToUser($user)->create();
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->patchJson(route('api.user.update', ['id' => $user->id]), [
+            'email' => $user->email,
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonMissingPath('data.errors');
+    }
+
+    /** @test */
+    public function it_has_error_input_unique_user_email(): void
+    {
+        Date::setTestNow();
+        $user = User::factory()->create(['email' => 'john@mail.com']);
+        User::factory()->create(['email' => 'johndoe@mail.com']);
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->patchJson(route('api.user.update', $user->id), [
+            'email' => 'johndoe@mail.com',
+        ]);
+
+        $response
+            ->assertUnprocessable()
+            ->assertJson([
+                'data' => [
+                    'errors' => [
+                        'email' => [
+                            __('validation.unique', ['attribute' => 'email']),
+                        ],
+                    ],
+                ],
+                'meta' => [
+                    'statusText' => 'unprocessable entity',
+                    'timestamp'  => now()->toDateTimeLocalString(),
+                ],
+            ]);
+    }
+}

--- a/tests/Feature/Validations/UpdateUserRequest/ValidateInputUserFirstNameTest.php
+++ b/tests/Feature/Validations/UpdateUserRequest/ValidateInputUserFirstNameTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Feature\Validations\UpdateUserRequest;
+
+use App\Models\User;
+use App\Models\UserProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Date;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ValidateInputUserFirstNameTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    /** @test */
+    public function it_should_not_has_error_input_required_user_first_name(): void
+    {
+        Date::setTestNow();
+        $user = User::factory()->create();
+        UserProfile::factory()->belongsToUser($user)->create();
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->patchJson(route('api.user.update', ['id' => $user->id]), [
+            'userName' => $this->faker->userName,
+            'email'    => $this->faker->email,
+            'password' => $this->faker->password(11, 12),
+            'lastName' => $this->faker->lastName,
+            'dob'      => $this->faker->date(),
+            'location' => $this->faker->timezone,
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonMissingPath('data.errors');
+    }
+
+    /** @test */
+    public function it_has_error_input_max_length_user_first_name(): void
+    {
+        Date::setTestNow();
+        $user = User::factory()->create();
+        UserProfile::factory()->belongsToUser($user)->create();
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->patchJson(route('api.user.update', ['id' => $user->id]), [
+            'firstName' => str_repeat('john lark man', 11),
+        ]);
+
+        $response
+            ->assertUnprocessable()
+            ->assertJson([
+                'data' => [
+                    'errors' => [
+                        'firstName' => [
+                            __('validation.max.string', ['attribute' => 'first name', 'max' => 100]),
+                        ],
+                    ],
+                ],
+                'meta' => [
+                    'statusText' => 'unprocessable entity',
+                    'timestamp'  => now()->toDateTimeLocalString(),
+                ],
+            ])
+            ->assertJsonMissingPath('data.errors.userName')
+            ->assertJsonMissingPath('data.errors.email')
+            ->assertJsonMissingPath('data.errors.password')
+            ->assertJsonMissingPath('data.errors.lastName')
+            ->assertJsonMissingPath('data.errors.gender')
+            ->assertJsonMissingPath('data.errors.dob')
+            ->assertJsonMissingPath('data.errors.location');
+    }
+}

--- a/tests/Feature/Validations/UpdateUserRequest/ValidateInputUserGenderTest.php
+++ b/tests/Feature/Validations/UpdateUserRequest/ValidateInputUserGenderTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Feature\Validations\UpdateUserRequest;
+
+use App\Models\User;
+use App\Models\UserProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Date;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ValidateInputUserGenderTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    /** @test */
+    public function it_should_not_has_error_input_user_gender_the_value_is_unset(): void
+    {
+        Date::setTestNow();
+        $user = User::factory()->create();
+        UserProfile::factory()->belongsToUser($user)->create();
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->patchJson(route('api.user.update', ['id' => $user->id]), [
+            'email' => $this->faker->email,
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonMissingPath('data.errors');
+    }
+
+    /**
+     * @dataProvider invalidGenderValueDataProvider
+     *
+     * @test
+     *
+     * @param  string|int  $gender
+     */
+    public function it_has_error_input_user_gender_when_the_value_is_not_0_or_1(string|int $gender): void
+    {
+        Date::setTestNow();
+        $user = User::factory()->create();
+        UserProfile::factory()->belongsToUser($user)->create();
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->patchJson(route('api.user.update', ['id' => $user->id]), [
+            'gender' => $gender,
+        ]);
+
+        $response
+            ->assertUnprocessable()
+            ->assertJson([
+                'data' => [
+                    'errors' => [
+                        'gender' => [
+                            __('validation.in', ['attribute' => 'gender']),
+                        ],
+                    ],
+                ],
+                'meta' => [
+                    'statusText' => 'unprocessable entity',
+                    'timestamp'  => now()->toDateTimeLocalString(),
+                ],
+            ])
+            ->assertJsonMissingPath('data.errors.userName')
+            ->assertJsonMissingPath('data.errors.firstName')
+            ->assertJsonMissingPath('data.errors.lastName')
+            ->assertJsonMissingPath('data.errors.email')
+            ->assertJsonMissingPath('data.errors.password')
+            ->assertJsonMissingPath('data.errors.dob')
+            ->assertJsonMissingPath('data.errors.location');
+    }
+
+    /**
+     * Get invalid gender value
+     *
+     * @return array
+     */
+    public static function invalidGenderValueDataProvider(): array
+    {
+        return [
+            'using string gender male'      => ['male'],
+            'using string gender female'    => ['female'],
+            'using string gender man'       => ['man'],
+            'using string gender woman'     => ['woman'],
+            'using string gender boy'       => ['boy'],
+            'using string gender girl'      => ['girl'],
+            'using number where not 0 or 1' => [rand(3, 10)],
+        ];
+    }
+}

--- a/tests/Feature/Validations/UpdateUserRequest/ValidateInputUserLastNameTest.php
+++ b/tests/Feature/Validations/UpdateUserRequest/ValidateInputUserLastNameTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Feature\Validations\UpdateUserRequest;
+
+use App\Models\User;
+use App\Models\UserProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Date;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ValidateInputUserLastNameTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    /** @test */
+    public function it_should_not_has_error_input_required_user_last_name(): void
+    {
+        Date::setTestNow();
+        $user = User::factory()->create();
+        UserProfile::factory()->belongsToUser($user)->create();
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->patchJson(route('api.user.update', ['id' => $user->id]), [
+            'userName'  => $this->faker->userName,
+            'email'     => $this->faker->email,
+            'password'  => $this->faker->password(11, 12),
+            'firstName' => $this->faker->lastName,
+            'dob'       => $this->faker->date(),
+            'location'  => $this->faker->timezone,
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonMissingPath('data.errors');
+    }
+
+    /** @test */
+    public function it_has_error_input_max_length_user_last_name(): void
+    {
+        Date::setTestNow();
+        $user = User::factory()->create();
+        UserProfile::factory()->belongsToUser($user)->create();
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->patchJson(route('api.user.update', ['id' => $user->id]), [
+            'lastName' => str_repeat('john lark man', 11),
+        ]);
+
+        $response
+            ->assertUnprocessable()
+            ->assertJson([
+                'data' => [
+                    'errors' => [
+                        'lastName' => [
+                            __('validation.max.string', ['attribute' => 'last name', 'max' => 100]),
+                        ],
+                    ],
+                ],
+                'meta' => [
+                    'statusText' => 'unprocessable entity',
+                    'timestamp'  => now()->toDateTimeLocalString(),
+                ],
+            ])
+            ->assertJsonMissingPath('data.errors.userName')
+            ->assertJsonMissingPath('data.errors.email')
+            ->assertJsonMissingPath('data.errors.password')
+            ->assertJsonMissingPath('data.errors.firstName')
+            ->assertJsonMissingPath('data.errors.gender')
+            ->assertJsonMissingPath('data.errors.dob')
+            ->assertJsonMissingPath('data.errors.location');
+    }
+}

--- a/tests/Feature/Validations/UpdateUserRequest/ValidateInputUserLocationTest.php
+++ b/tests/Feature/Validations/UpdateUserRequest/ValidateInputUserLocationTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Feature\Validations\UpdateUserRequest;
+
+use App\Models\User;
+use App\Models\UserProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Date;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ValidateInputUserLocationTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    /** @test */
+    public function it_should_not_has_error_input_location_when_value_is_unset(): void
+    {
+        Date::setTestNow();
+        $user = User::factory()->create();
+        UserProfile::factory()->belongsToUser($user)->create();
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->patchJson(route('api.user.update', ['id' => $user->id]), [
+            'email' => $this->faker->email,
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonMissingPath('data.errors');
+    }
+
+    /**
+     * @dataProvider invalidLocationValueDataProvider
+     *
+     * @test
+     *
+     * @param  string  $locationFormat
+     */
+    public function it_has_error_input_user_location_when_the_value_incorrect_timezone(string $locationFormat): void
+    {
+        Date::setTestNow();
+        $user = User::factory()->create();
+        UserProfile::factory()->belongsToUser($user)->create();
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->patchJson(route('api.user.update', ['id' => $user->id]), [
+            'location' => $locationFormat,
+        ]);
+
+        $response
+            ->assertUnprocessable()
+            ->assertJson([
+                'data' => [
+                    'errors' => [
+                        'location' => [
+                            __('validation.timezone', ['attribute' => 'location']),
+                        ],
+                    ],
+                ],
+                'meta' => [
+                    'statusText' => 'unprocessable entity',
+                    'timestamp'  => now()->toDateTimeLocalString(),
+                ],
+            ])
+            ->assertJsonMissingPath('data.errors.userName')
+            ->assertJsonMissingPath('data.errors.firstName')
+            ->assertJsonMissingPath('data.errors.lastName')
+            ->assertJsonMissingPath('data.errors.email')
+            ->assertJsonMissingPath('data.errors.password')
+            ->assertJsonMissingPath('data.errors.dob')
+            ->assertJsonMissingPath('data.errors.gender');
+    }
+
+    /**
+     * Get invalid location value
+     *
+     * @return array
+     */
+    public static function invalidLocationValueDataProvider(): array
+    {
+        return [
+            'using invalid timezone code' => ['ABC'],
+            'using continent only'        => ['Asia'],
+            'using city only'             => ['Jakarta'],
+        ];
+    }
+}

--- a/tests/Feature/Validations/UpdateUserRequest/ValidateInputUserNameTest.php
+++ b/tests/Feature/Validations/UpdateUserRequest/ValidateInputUserNameTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Feature\Validations\UpdateUserRequest;
+
+use App\Models\User;
+use App\Models\UserProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Date;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ValidateInputUserNameTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    /** @test */
+    public function it_should_not_receive_error_input_unique_user_name_if_the_value_is_similar_with_existing_user_name(): void
+    {
+        Date::setTestNow();
+        $user = User::factory()->create(['name' => $this->faker->userName]);
+        UserProfile::factory()->belongsToUser($user)->create();
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->patchJson(route('api.user.update', ['id' => $user->id]), [
+            'userName' => $user->name,
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonMissingPath('data.errors');
+    }
+
+    /** @test */
+    public function it_has_error_input_unique_user_name(): void
+    {
+        Date::setTestNow();
+        $user = User::factory()->create(['name' => $this->faker->userName]);
+        User::factory()->create(['name' => 'johndoe']);
+        Sanctum::actingAs($user, ['access-api']);
+
+        $response = $this->patchJson(route('api.user.update', $user->id), [
+            'userName' => 'johndoe',
+        ]);
+
+        $response
+            ->assertUnprocessable()
+            ->assertJson([
+                'data' => [
+                    'errors' => [
+                        'userName' => [
+                            __('validation.unique', ['attribute' => 'user name']),
+                        ],
+                    ],
+                ],
+                'meta' => [
+                    'statusText' => 'unprocessable entity',
+                    'timestamp'  => now()->toDateTimeLocalString(),
+                ],
+            ]);
+    }
+}

--- a/tests/Unit/Http/FormRequests/UpdateUserRequestTest.php
+++ b/tests/Unit/Http/FormRequests/UpdateUserRequestTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit\Http\FormRequests;
+
+use App\Enums\Gender;
+use App\Http\Requests\User\UpdateUserRequest;
+use Illuminate\Validation\Rule;
+use PHPUnit\Framework\TestCase;
+
+class UpdateUserRequestTest extends TestCase
+{
+    /** @test */
+    public function it_will_always_authorize(): void
+    {
+        $request = new UpdateUserRequest();
+
+        $this->assertTrue($request->authorize());
+    }
+
+    /** @test */
+    public function it_should_contains_the_given_field_rules(): void
+    {
+        $request = new UpdateUserRequest();
+        $request->id = 1;
+
+        $rules = $request->rules();
+
+        $this->assertEquals([
+            'userName'  => ['nullable', Rule::unique('users', 'name')->ignore(1)],
+            'email'     => ['nullable', Rule::unique('users', 'email')->ignore(1)],
+            'password'  => ['nullable', 'min:11'],
+            'firstName' => ['nullable', 'max:100'],
+            'lastName'  => ['nullable', 'max:100'],
+            'gender'    => ['nullable', Rule::in(Gender::values())],
+            'dob'       => ['nullable', 'date_format:Y-m-d'],
+            'location'  => ['nullable', 'timezone:all'],
+        ], $rules);
+    }
+
+    /** @test */
+    public function it_should_contains_specified_custom_attributes(): void
+    {
+        $request = new UpdateUserRequest();
+
+        $rules = $request->attributes();
+
+        $this->assertEquals([
+            'userName'  => 'user name',
+            'firstName' => 'first name',
+            'lastName'  => 'last name',
+            'dob'       => 'date of birth',
+        ], $rules);
+    }
+}

--- a/tests/Unit/Http/Resources/UserResourceTest.php
+++ b/tests/Unit/Http/Resources/UserResourceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Unit\Http\Resources;
+
+use App\Http\Resources\UserResource;
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class UserResourceTest extends TestCase
+{
+    /** @test */
+    public function it_will_return_http_enum_200(): void
+    {
+        Mockery::mock(Carbon::class);
+        $mockRequest = Mockery::spy(Request::class);
+        $mockRequest->shouldReceive('routeIs')->with('api.user.update')->andReturnTrue();
+        $mockResponse = Mockery::spy(JsonResponse::class);
+        $resource = new UserResource([]);
+
+        $resource->withResponse($mockRequest, $mockResponse);
+
+        $this->assertEquals('ok', $resource->with($mockRequest)['meta']['statusText']);
+        $mockResponse->shouldHaveReceived('setStatusCode')->with(200)->once();
+    }
+
+    /** @test */
+    public function it_will_return_http_enum_201(): void
+    {
+        Mockery::mock(Carbon::class);
+        $mockRequest = Mockery::spy(Request::class);
+        $mockRequest->shouldReceive('routeIs')->with('api.user.register')->andReturnTrue();
+        $mockResponse = Mockery::spy(JsonResponse::class);
+        $resource = new UserResource([]);
+
+        $resource->withResponse($mockRequest, $mockResponse);
+
+        $this->assertEquals('created', $resource->with($mockRequest)['meta']['statusText']);
+        $mockResponse->shouldHaveReceived('setStatusCode')->with(201)->once();
+    }
+
+    /** @test */
+    public function it_will_return_http_enum_500(): void
+    {
+        Mockery::mock(Carbon::class);
+        $mockRequest = Mockery::spy(Request::class);
+        $mockRequest->shouldReceive('routeIs')->withAnyArgs()->andReturnFalse();
+        $mockResponse = Mockery::spy(JsonResponse::class);
+        $resource = new UserResource([]);
+
+        $resource->withResponse($mockRequest, $mockResponse);
+
+        $this->assertEquals('internal server error', $resource->with($mockRequest)['meta']['statusText']);
+        $mockResponse->shouldHaveReceived('setStatusCode')->with(500)->once();
+    }
+}


### PR DESCRIPTION
### Overview:
This pull request addresses the task ticket RMA-09, aimed at implementing the API endpoint responsible for updating user information. The primary focus was to enable users to modify their profile details via API calls.

### Changes Made:
- Created a new API endpoint `PATCH: /api/user/{id}` to handle user updates.
- Implemented logic to process and validate user input for profile updates.
- Integrated error handling to manage edge cases and provide appropriate responses.
- Ensured that only authenticated users could access and update their respective profiles.

### Checklist:
- [x] Implemented the `PUT` method for updating user details.
- [x] Validated and sanitized incoming user data.
- [x] Integrated proper error handling and response messages.
- [x] Secured endpoint access for authenticated users only using auth sanctum & sanctum ability middleware.

### Additional Notes:
The endpoint allows users to modify specific details within their profiles, adhering to the outlined requirements in ticket RMA-09. Testing has been conducted to verify the functionality and security of the endpoint.

---